### PR TITLE
Use Response class from node-fetch and some bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solid-rest",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Jeff Zucker",
   "license": "MIT",
   "description": "treat any storage as a mini Solid server",

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -137,8 +137,9 @@ async deleteContainer(pathname,options){
 */
 async makeContainers(pathname,options){
   let [t,exists] = await this.getObjectType(pathname);
-  if(exists) return Promise.resolve(201)
+  if(exists) return Promise.resolve([201])
 //  let containers = pathname.split('/');
+  // TODO: Recursively create containers
   return Promise.resolve( [201] )
 }
 }

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -49,9 +49,11 @@ async getResource(pathname,options){
     * OR returns a turtle representation of the container and contents
 */
 async getContainer(pathname,options) {
-  let files = Object.keys(localStorage).filter( k=>{
-    if(k.startsWith(pathname) && k != pathname){ return k }
-  }).map(v=>{return v.replace(pathname,'')})
+  const files = Object.keys(localStorage)
+    .filter(path => path.startsWith(pathname) && path != pathname) // Only children
+    .map(path => path.substr(pathname.length))
+    .filter(path => !path.slice(0, -1).includes("/")) // Only include direct children
+
   return files
 }
 

--- a/src/rest.js
+++ b/src/rest.js
@@ -153,7 +153,7 @@ async fetch(uri, options) {
       for(var i=0;i<filenames.length;i++){
         let fn = filenames[i]
         let [ftype,e] =  await self.storage(options).getObjectType(pathname + fn)
-        if(ftype==="Container") fn = fn + "/"
+        if(ftype==="Container" && !fn.endsWith("/")) fn = fn + "/"
 //        let prefix = options.rest_prefix==="file" ? "" : options.rest_prefix
 //        fn = options.scheme+"//"+prefix+pathname + fn
         str = str + `  <${fn}>,\n`


### PR DESCRIPTION
I've switched to use the node-fetch.Response class instead of a manually created object. It now also supports blob, url and likely some other properties too. The `_response` function now accepts the content, the options and the status code (if the status code is not defined as third parameter it is read from the options. I just thought it would be handy to have it separate). For instance `_response(turtleContents, options, 200)` would be possible.

The errors I've fixed:
localStorage -> getContainer now only lists direct children (e.g. if called on folder it lists folder/child/ but not folder/child/file.ttl)
localStorage -> makeContainers now returns an array
rest -> _container2turtle now doesn't append a slash to a folder path if it already ends with a slash

I've tested it with the tests from SolidApi.core.test.js and SolidApi.composed.test.js and the old stuff plus the blob and url stuff worked.