### PR TITLE
Add support to node-fetch Blobs in file.js

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -9,12 +9,15 @@ class SolidFileStorage {
     this.name = "solid-rest-file-storage-1.0.0"
   }
 
- _makeStream(text){
-      let s = new Readable
-      s.push(text)
-      s.push(null)  
-      return s;
-}
+  _makeStream(text){
+    if (typeof text === 'object' && typeof text.stream === 'function') {
+      return text.stream()
+    }
+       let s = new Readable
+       s.push(text)
+       s.push(null)  
+       return s;
+ }
  async text (stream) {
   return new Promise((resolve, reject) => {
     stream = stream || ""


### PR DESCRIPTION
With this change one can use node-fetch Blobs to store files in file://

Status of other blob usage:
All storages support it in the response.
For put/post requests:
In the in-memory storage (app://ls without window.localStorage) it also works, as blobs as stored as objects.
In the local storage it likely does not work, as localStorage.setItem(key, val) expects val to be a string. It maybe is enough if we convert it to a string as described [here](https://stackoverflow.com/a/23024504/6548154) or to dataUrl string (same code as in the other, but with .readAsDataUrl(blob)), but I could imagine that some data gets malformed in this process. Something that should be tested with binary files.