### PR TITLE
Don't set Content-Type if unknown

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -184,6 +184,8 @@ async fetch(uri, options) {
       options.objectType==="Container"
         ? "text/turtle"
         : contentTypeLookup(path.extname(pathname))
+    if (!headers['content-type'])
+      delete headers['content-type']
     return headers
   } // end of getHeaders()
  } // end of fetch()


### PR DESCRIPTION
Currently the Content-Type is set to "false" if it is no container and contentTypeLookup doesn't find a suitable type. I'd propose to not set it in such a scenario (as done in this PR) or to use a default (eg "text/turtle"). The first solution seems more clean to me.