### PR TITLE
Make getResource of file.js work for binary data

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -42,21 +42,13 @@ async  getObjectType(fn,options){
 }
 
 async getResource(pathname,options,objectType){
- return new Promise((resolve) => {
   let fn = pathname.replace(/.*\//,'');    
-  let success="";
-  try{ 
-     fs.createReadStream(pathname)
-    .on("data",(chunk)=>{success=success+chunk})
-    .on("error",(err)=>{console.log(err)})
-    .on("end",()=>{
-      return resolve( [
-        200,
-        success
-      ])
-    })
-  }catch(e){}
-})}
+  const bodyData = fs.createReadStream(fn)
+  return [
+    200,
+    bodyData
+  ]
+}
 
 async putResource(pathname,options){
     return new Promise((resolve) => {


### PR DESCRIPTION
Tested with uploading and downloading from/to NSS: .png, .ttl, .json

Note: The Response constructor of node-fetch supports among other things a stream. And streams can handle binary data, so I've used this. Converting binary data to strings usually doesn't work without breaking it.

Fixes https://github.com/jeff-zucker/solid-file-client/issues/110