### PR TITLE
Fix typo in rest.js

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -174,7 +174,7 @@ async fetch(uri, options) {
     if( ext==='.ttl'
      || ext==='.acl'
      || ext==='.meta'
-     || type==="Containter"
+     || type==="Container"
     ) {
       return 'text/turtle'
     }


### PR DESCRIPTION
I'd suggest to use a constant for that, so such typos cannot happen. Fixes some tests in solid-file-client.