### PR TITLE
refactor delete with links in rest.js

### DIFF
--- a/src/browserFS.js
+++ b/src/browserFS.js
@@ -137,28 +137,12 @@ async postContainer(pathname,options){
 }
 
 /*
-  deleteResource(pathname,options)
-    * deletes a resource with links
+  deleteFile(pathname,options)
+    * deletes a fle
     * on success, returns [200,undefined,optionalHeader]
     * on failure, returns [500,undefined,optionalHeader]
 */
-async deleteResource(pathname,options){
-  const folderLinks = pathname.endsWith('/') ? pathname : _getParent(pathname)
-  let files = await this.getContainer(folderLinks,options)
-  let fileName = pathname.replace(folderLinks, '')
-  let links = files.filter(file => (file.endsWith(fileName + '.meta') || file.endsWith(fileName + '.acl')))
-  links = links.map(file => folderLinks + file)
-  if (links.length) links.map(async link => await this.deleteItem(link,options))
-  return await this.deleteItem(pathname,options)
-}
-
-/*
-  deleteItem(pathname,options)
-    * deletes a resource
-    * on success, returns [200,undefined,optionalHeader]
-    * on failure, returns [500,undefined,optionalHeader]
-*/
-async deleteItem(pathname,options){
+async deleteFile(pathname,options){
   try {
     let res = await this.prom(this.fs.unlink,pathname)
     if(res && res.code) { 
@@ -168,22 +152,13 @@ async deleteItem(pathname,options){
   }
   catch(e){ console.warn(e); return Promise.resolve( [500] ) }    
 }
+
 /*
-  deleteContainer(pathname,options)
-    * if container is not empty, returns [409,undefined,optionalHeader]
-    * else deletes container
+  deleteDir(pathname,options)
+    * deletes a folder
     * on success, returns [200,undefined,optionalHeader]
     * on failure, returns [500,undefined,optionalHeader]
 */
-async deleteContainer(pathname){
-  let files = await this.getContainer(pathname)
-  let links = files.filter(file => (file.endsWith('.meta') || file.endsWith('.acl')))
-  links = links.map(file => pathname + file)
-  files = files.filter(file => (!file.endsWith('.meta') && !file.endsWith('.acl')))
-  if( files.length ){ return Promise.resolve( [409] ) }
-  if (links.length) links.map(async link => await this.deleteItem(link))
-  return this.deleteDir(pathname)
-}
 async deleteDir(pathname,options){
   try {
       let res = await this.prom(this.fs.rmdir,pathname)

--- a/src/file.js
+++ b/src/file.js
@@ -118,31 +118,13 @@ async putResource(pathname,options){
         }
     })
 }
-async deleteResource (pathname, options) {
-  const folderLinks = pathname.endsWith('/') ? pathname : getParent(pathname)
-  let files = await this.getContainer(folderLinks,options)
-  let fileName = pathname.replace(folderLinks, '')
-  let links = files.filter(file => (file.endsWith(fileName + '.meta') || file.endsWith(fileName + '.acl')))
-  links = links.map(file => folderLinks + file)
-  if (links.length) links.map(async link => await this.deleteItem(link,options))
-  return await this.deleteItem(pathname,options)
-}
-async deleteItem(fn){
+async deleteFile(fn){
     return new Promise(function(resolve) {
         fs.unlink( fn, function(err) {
             if(err)  resolve( [409] );
             else     resolve( [200] );
         });
     });
-}
-async deleteContainer(pathname){
-  let files = await this.getContainer(pathname)
-  let links = files.filter(file => (file.endsWith('.meta') || file.endsWith('.acl')))
-  links = links.map(file => pathname + file)
-  files = files.filter(file => (!file.endsWith('.meta') && !file.endsWith('.acl')))
-  if( files.length ){ return Promise.resolve( [409] ) }
-  if (links.length) links.map(async link => await this.deleteItem(link))
-  return this.deleteDir(pathname)
 }
 
 deleteDir(fn) {

--- a/src/localStorage.js
+++ b/src/localStorage.js
@@ -53,16 +53,7 @@ async getContainer(pathname,options) {
     .filter(path => path.startsWith(pathname) && path != pathname) // Only children
     .map(path => path.substr(pathname.length))
     .filter(path => !path.slice(0, -1).includes("/")) // Only include direct children
-//console.log(files)
     return files
-}
-
-async getLinks(pathname, options) {
-  let folderLinks = pathname.endsWith('/') ? pathname : getParent(pathname)
-  let links = await this.getContainer(folderLinks, options)
-  links = links.filter(file => (file.endsWith('.meta') || file.endsWith('.acl')))
-    .map(file => folderLinks + file)
-  return links
 }
 
 dump(pathname,options) {
@@ -109,49 +100,26 @@ async postContainer(pathname,options){
   return this.putResource(pathname,options)
 }
 
-/*
-  deleteResource(pathname,options)
-    * deletes a resource with links
+/**
+ * deleteFile(pathname, options)
     * on success, returns [200,undefined,optionalHeader]
     * on failure, returns [500,undefined,optionalHeader]
-*/
-async deleteResource(pathname,options){
-  const folderLinks = pathname.endsWith('/') ? pathname : getParent(pathname)
-  let files = await this.getContainer(folderLinks,options)
-  let fileName = pathname.replace(folderLinks, '')
-  let links = files.filter(file => (file.endsWith(fileName + '.meta') || file.endsWith(fileName + '.acl')))
-  links = links.map(file => folderLinks + file)
-  if (links.length) links.map(async link => await this.deleteItem(link,options))
-  return await this.deleteItem(pathname,options)
-}
-
-/**
- * deleteItem(pathname, options)
- * @param {*} pathname 
- * @param {*} options 
  */
-async deleteItem(pathname,options){
+async deleteFile(pathname,options){
   try {
     localStorage.removeItem(pathname)
     return Promise.resolve( [200] )
   }
   catch(e){ return Promise.resolve( [500] ) }    
 }
-/*
-  deleteContainer(pathname,options)
-    * if container is not empty, returns [409,undefined,optionalHeader]
-    * else deletes container
+
+/**
+ * deleteFile(pathname, options)
     * on success, returns [200,undefined,optionalHeader]
     * on failure, returns [500,undefined,optionalHeader]
-*/
-async deleteContainer(pathname,options){
-  let files = await this.getContainer(pathname,options)
-  let links = files.filter(file => (file.endsWith('.meta') || file.endsWith('.acl')))
-  links = links.map(file => pathname + file)
-  files = files.filter(file => (!file.endsWith('.meta') && !file.endsWith('.acl')))
-  if( files.length ){ return Promise.resolve( [409] ) }
-  if (links.length) links.map(async link => await this.deleteItem(link,options))
-  return await this.deleteItem(pathname,options)
+ */
+async deleteDir (pathname, options) {
+  return await this.deleteFile(pathname, options)
 }
 
 async makeContainers(pathname,options){

--- a/tests/all.js
+++ b/tests/all.js
@@ -49,9 +49,10 @@ async function getConfig(scheme){
   let  c2name = "deep-folder"
   let  r1name = "test1.ttl"
   let  r2name = "test2.ttl"
+  let  meta = '.meta'
   let  folder1 = base +"/"+ c1name
   let  folder2 =  folder1 + c2name + "/"
-  let  folder2acl = folder2 + '.acl'
+  let  folder2meta = folder2 + meta
   let  deepR  =  folder2 +"test-file2.ttl"
   let  deepRacl = folder2 + "test-file2.ttl.acl"
   let  file1  = folder1 + r1name
@@ -64,9 +65,10 @@ async function getConfig(scheme){
     c2name : c2name,
     r1name : r1name,
     r2name : r2name,
+    meta : meta,
     folder1 : folder1,
     folder2 : folder2,
-    folder2acl : folder2acl,
+    folder2meta : folder2meta,
     deepR  :  deepR,
     deepRacl : deepRacl,
     file1  : file1,
@@ -103,6 +105,9 @@ async function run(scheme){
   res = await postFolder( cfg.missingFolder,cfg.c2name )
   ok( "404 post container, parent not found", res.status==404,res)
 
+  res = await postFile( cfg.folder2meta,cfg.meta )
+  ok( "403 post link resource", res.status==404,res)
+
   res = await postFile( cfg.folder1,cfg.r1name,cfg.text )
   ok( "201 post resource", res.status==201,res)
 
@@ -124,7 +129,7 @@ async function run(scheme){
   res = await PUT( cfg.deepR,cfg.text )
   ok("201 put resource, parent not found (recursive creation)",res.status==201)
 
-  res = await PUT( cfg.folder2acl,cfg.text )
+  res = await PUT( cfg.folder2meta,cfg.text )
   ok("201 put container acl",res.status==201)
 
   res = await PUT( cfg.deepRacl,cfg.text )
@@ -153,6 +158,7 @@ async function run(scheme){
   res = await DELETE( cfg.base+'dummy.txt' )
   res = await DELETE( cfg.file1 )
   res = await DELETE( cfg.deepR )
+  res = await DELETE( cfg.folder2meta)
   ok("200 delete resource",res.status==200,res)
 
   if(scheme != "https:"){


### PR DESCRIPTION
 @jeff-zucker 
I refactored the delete with links functions in `rest.js.` Passes all tests (added 2)
This is solid spec and not file system related.

- `_deleteContainer() `and `_deleteResource()` in rest.js
- create a `_getLinks()` and `isLink()` in rest.js (may be it should be `_isLink()`)
- Renamed in each storage handler : 
`deleteResource -> deleteFile`
`deleteContainer -> deleteDir`
Hope this do not raise issues on actual `storageHandler` usage. (not used in your browser test)

added POST forbidden (403) for links. Need to use PUT see issue #28  