### PR TITLE
Include build files by adding .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+tests
+webpack
+solid-rest.png

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "description": "treat any storage as a mini Solid server",
   "main": "./src/rest.js",
-  "module": "./dist/main.js",
   "scripts": {
     "prepublish": "npm run build",
     "build": "npm run build:window",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "license": "MIT",
   "description": "treat any storage as a mini Solid server",
   "main": "./src/rest.js",
-  "browser": "./dist/browser/solid-rest.js",
-  "module": "lib/rest.js",
+  "module": "./dist/main.js",
   "scripts": {
     "prepublish": "npm run build",
     "build": "npm run build:window",

--- a/src/file.js
+++ b/src/file.js
@@ -162,7 +162,7 @@ async makeContainers(pathname, options){
       fs.mkdirpSync(foldername);
       return Promise.resolve([201])
     }
-    catch {
+    catch (err) {
       return Promise.resolve([500])
     }
   }


### PR DESCRIPTION
If npm finds no .npmignore it uses the .gitignore file as a default which lead to the dist files being excluded. Adding this should fix it.

Also remove `module` field in package.json (see issue for more info).

Closes #30 